### PR TITLE
Supports Fortify SCA 16+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.idea/
+target/
+work/
+fortify360.iml
+

--- a/pom.xml
+++ b/pom.xml
@@ -3,10 +3,9 @@
   <description>Fortify 360 FPR post-processing and uploading to Fortify 360 Server</description>
   <url>http://wiki.jenkins-ci.org/display/JENKINS/Fortify+360+Plugin</url>
   <parent>
-    <groupId>org.jvnet.hudson.plugins</groupId>
+    <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.323</version><!-- which version of Hudson is this plugin built against? -->
-    <relativePath>../pom.xml</relativePath>
+    <version>2.2</version>
   </parent>
 
   <groupId>org.jvnet.hudson.plugins.fortify360</groupId>
@@ -119,6 +118,7 @@
   
   <properties>
   	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <jenkins.version>1.420</jenkins.version>
   </properties>
   
   <distributionManagement>

--- a/src/main/java/org/jvnet/hudson/plugins/fortify360/RemoteService.java
+++ b/src/main/java/org/jvnet/hudson/plugins/fortify360/RemoteService.java
@@ -1,9 +1,8 @@
 package org.jvnet.hudson.plugins.fortify360;
 
 import java.util.*;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipException;
-import java.util.zip.ZipFile;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.io.*;
 
 import hudson.FilePath;

--- a/src/main/java/org/jvnet/hudson/plugins/fortify360/RemoteService.java
+++ b/src/main/java/org/jvnet/hudson/plugins/fortify360/RemoteService.java
@@ -20,6 +20,7 @@ import org.dom4j.io.SAXReader;
 public class RemoteService implements FilePath.FileCallable<FPRSummary> {
 	
 	private static final long serialVersionUID = 229830219491170076L;
+	private static final Pattern FORTIFY_VERSION_PATTERN = Pattern.compile("Fortify Static Code Analyzer ([0-9\\.]+)");
 	private String fpr;
 	private String filterSet;
 	private String searchCondition;
@@ -388,11 +389,20 @@ public class RemoteService implements FilePath.FileCallable<FPRSummary> {
 		BufferedReader br = new BufferedReader(new InputStreamReader(in));
 		String line = br.readLine();
 		if ( null != line ) {
-			line = line.trim();
-			int x = line.lastIndexOf(' ');
-			if ( -1 != x ) {
-				String scaVersion = line.substring(x).trim();
-				return scaVersion;
+			// using pattern matcher since SCA 16+ will dump used java version like:
+			//   HPE Security Fortify Static Code Analyzer 16.10.0095 (using JVM 1.8.0_72)
+			Matcher matcher = FORTIFY_VERSION_PATTERN.matcher(line);
+			if (matcher.find()) {
+				return matcher.group(1);
+
+			} else {
+				// fallback to legacy version extracting method
+				line = line.trim();
+				int x = line.lastIndexOf(' ');
+				if (-1 != x) {
+					String scaVersion = line.substring(x).trim();
+					return scaVersion;
+				}
 			}
 		}
 		

--- a/src/main/java/org/jvnet/hudson/plugins/fortify360/UploadFprService.java
+++ b/src/main/java/org/jvnet/hudson/plugins/fortify360/UploadFprService.java
@@ -32,7 +32,7 @@ public class UploadFprService implements FileCallable<Integer>, Serializable {
 		System.out.println("Inside uploadToF360 FileCallable invoke");
 		System.out.println("f is " + f);
 		
-		// fortifyclient uploadFPR –projectID <proj_ID> -file XXX.fpr -url http://fortify.ca.com:8080/f360 -authtoken XXXX
+		// fortifyclient uploadFPR -projectID <proj_ID> -file XXX.fpr -url http://fortify.ca.com:8080/f360 -authtoken XXXX
 		String array[] = {"fortifyclient", "uploadFPR", "-projectID", "unknown", "-file", "unknown", "-url", "unknown", "-authtoken", "unknown"};
 		
 		String os = System.getProperty("os.name");


### PR DESCRIPTION
This PR fixed following exception with SCA 16+:

```
14:04:05 Publishing Fortify 360 FPR Data
14:04:17 ERROR: Build step failed with exception
14:04:17 java.lang.NumberFormatException: For input string: "0_72)"
14:04:17 	at java.lang.NumberFormatException.forInputString(NumberFormatException.java:65)
14:04:17 	at java.lang.Integer.parseInt(Integer.java:580)
14:04:17 	at java.lang.Integer.parseInt(Integer.java:615)
14:04:17 	at org.jvnet.hudson.plugins.fortify360.VersionNumber.<init>(VersionNumber.java:22)
14:04:17 	at org.jvnet.hudson.plugins.fortify360.RemoteService.isNewFPO(RemoteService.java:375)
14:04:17 	at org.jvnet.hudson.plugins.fortify360.RemoteService.invoke(RemoteService.java:77)
14:04:17 	at org.jvnet.hudson.plugins.fortify360.RemoteService.invoke(RemoteService.java:23)
14:04:17 	at hudson.FilePath.act(FilePath.java:1018)
14:04:17 	at hudson.FilePath.act(FilePath.java:996)
14:04:17 	at org.jvnet.hudson.plugins.fortify360.FPRPublisher.perform(FPRPublisher.java:152)
14:04:17 	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
14:04:17 	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:779)
14:04:17 	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:720)
14:04:17 	at hudson.model.Build$BuildExecution.post2(Build.java:185)
14:04:17 	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:665)
14:04:17 	at hudson.model.Run.execute(Run.java:1745)
14:04:17 	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
14:04:17 	at hudson.model.ResourceController.execute(ResourceController.java:98)
14:04:17 	at hudson.model.Executor.run(Executor.java:410)
```